### PR TITLE
com_search-Fix

### DIFF
--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -347,6 +347,11 @@ class SearchHelper
 		}
 		else
 		{
+			if (($mbtextlen = mb_strlen($text)) < $length)
+			{
+				$length = $mbtextlen;
+			}
+
 			if (($wordpos = @StringHelper::strpos($text, ' ', $length)) !== false)
 			{
 				return StringHelper::substr($text, 0, $wordpos) . '&#160;...';


### PR DESCRIPTION
Voraussetzungen:
- Joomla 3.9.25
- PHP **_8_**
- Suche mit "normaler" Joomla-Suche `com_search`. Nicht Suchindex-Suche.
- Das Suchwort befindet sich im Artikel-Text. z.B. Suchwort `Modulstil`
- Das Suchwort befindet sich aber **_NICHT(!!!)_** in der Artikel-Überschrift (= Artikel-Titel)..
- **Die Überschrift enthält einen oder mehr Umlaute.**

Fehler:
- Die Suche hängt sich auf mit Fehler `0 mb_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)`

Temporäre Lösung:
- Siehe https://github.com/ReLater/j3925-com_search-bug/pull/1/files
- Grüner Code rein in `administrator/components/com_search/helpers/search.php` 

Bei Interesse:
- Siehe auch https://github.com/joomla/joomla-cms/issues/32115
- <strike>Siehe auch https://github.com/joomla/joomla-cms/pull/32638</strike>
- Siehe auch https://github.com/joomla/joomla-cms/pull/33113/files